### PR TITLE
Add natural blackjack payout for player

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -44,14 +44,24 @@ class Game
   end
 
   def automatic_win
-      if first_hand_blackjack(@dealer.cards.first,@dealer.cards.last)
-        puts "\nDealer has a blackjack. Playes loses."
+    player_blackjack = @player1.hand.blackjack?
+    dealer_blackjack = @dealer.blackjack?
+
+    if player_blackjack && dealer_blackjack
+      puts "\nBoth player 1 and dealer have blackjack. It's a push."
+      true
+    elsif player_blackjack
+      puts "\nPlayer 1 has a blackjack!"
+      @player1.money.win_blackjack
+      true
+    elsif dealer_blackjack
+      puts "\nDealer has a blackjack. Player loses."
       @player1.money.lose_money
-      return true
+      true
     else
-      return false
+      false
     end
-  end  
+  end
 
   def surrender?
     if @dealer.cards.first.value == :Ace
@@ -61,7 +71,7 @@ class Game
         puts "Player 1 surrenders."
         @player1.money.lose_money_by_half
         return true
-      elsif first_hand_blackjack(@dealer.cards.first, @dealer.cards.last)
+      elsif @dealer.blackjack?
         @player1.money.lose_money
         puts "\n Dealer has a blackjack. Dealer wins."
         return true
@@ -69,22 +79,9 @@ class Game
         return false
       end
     else
-    end 
+    end
   end
 
-#  def hidden_unmatched_blackjack?(dealer,player1)
-#    if dealer.cards.first.check_card_points == 10 && dealer.cards.last.value == :Ace && player1.cards.
-#    else 
-#    end
-#  end
-
-  def first_hand_blackjack(card1,card2)
-    if card1.check_card_points == 10 && card2.value == :Ace
-      return true
-    else
-      return false
-  end
- end 
   def turn
     puts "\nPlayer 1 do you want to draw a card?\n yes / no / score ."
     choice = gets.chomp

--- a/hand.rb
+++ b/hand.rb
@@ -31,6 +31,10 @@ class Hand
     "#{@cards.join(", ")}"
   end
 
+  def blackjack?
+    @cards.length == 2 && points == 21
+  end
+
 end
 
 

--- a/money.rb
+++ b/money.rb
@@ -21,6 +21,10 @@ class Money
     @amount = @amount + bet
   end
 
+  def win_blackjack
+    @amount = @amount + bet * 3 / 2.0
+  end
+
   def to_s
     "#{@amount}"
   end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -12,29 +12,49 @@ describe Game do
     expect(subject.dealer.cards.size).to eq(2)
   end
 
-  it "Dealer wins if they have a hidden blackjack and player doesn't" do
-    subject.set_up
-    card1 = Card.new(:King, :Diamonds)
-    card2 = Card.new(:Ace, :Diamonds)
-    subject.dealer.cards.clear
-    subject.dealer.add_card(card1)
-    subject.dealer.add_card(card2)
-    expect(subject.first_hand_blackjack(card1, card2)).to eq(true)
+  describe '#automatic_win' do
+    before do
+      subject.player1.money.instance_variable_set(:@amount, 10)
     end
 
-  it "Player wins if they have a blackjack and dealer doesn't" do
-    subject.set_up
-    card1 = Card.new(:King, :Diamonds)
-    card2 = Card.new(:Ace, :Diamonds)
-    subject.player1.hand.cards.clear
-    subject.player1.hand.add_card(card1)
-    subject.player1.hand.add_card(card2)
-    card3 = Card.new(:King, :Diamonds)
-    card4 = Card.new(:Queen, :Diamonds)
-    subject.dealer.cards.clear
-    subject.dealer.add_card(card3)
-    subject.dealer.add_card(card4)
-    expect(subject.first_hand_blackjack(subject.player1.hand.cards.first, subject.player1.hand.cards.last)).to eq(true)
+    it "resolves to a push when both player and dealer have blackjack" do
+      subject.player1.hand.cards.clear
+      subject.player1.hand.add_card(Card.new(:Ace, :Spades))
+      subject.player1.hand.add_card(Card.new(:King, :Hearts))
+
+      subject.dealer.cards.clear
+      subject.dealer.add_card(Card.new(:Ace, :Clubs))
+      subject.dealer.add_card(Card.new(:Queen, :Diamonds))
+
+      expect(subject.automatic_win).to eq(true)
+      expect(subject.player1.money.amount).to eq(10)
+    end
+
+    it "pays 3:2 when only the player has blackjack" do
+      subject.player1.hand.cards.clear
+      subject.player1.hand.add_card(Card.new(:Ace, :Spades))
+      subject.player1.hand.add_card(Card.new(:King, :Hearts))
+
+      subject.dealer.cards.clear
+      subject.dealer.add_card(Card.new(:Nine, :Clubs))
+      subject.dealer.add_card(Card.new(:Seven, :Diamonds))
+
+      expect(subject.automatic_win).to eq(true)
+      expect(subject.player1.money.amount).to eq(17.5)
+    end
+
+    it "causes an immediate loss when only the dealer has blackjack" do
+      subject.player1.hand.cards.clear
+      subject.player1.hand.add_card(Card.new(:Nine, :Clubs))
+      subject.player1.hand.add_card(Card.new(:Seven, :Diamonds))
+
+      subject.dealer.cards.clear
+      subject.dealer.add_card(Card.new(:Ace, :Spades))
+      subject.dealer.add_card(Card.new(:King, :Hearts))
+
+      expect(subject.automatic_win).to eq(true)
+      expect(subject.player1.money.amount).to eq(5)
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- detect blackjack hands for both the player and dealer
- award a 3:2 payout to the player on a natural blackjack and handle pushes
- expand automatic win specs to cover the new outcomes

## Testing
- ⚠️ `rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d998294fe0832d90c8696cf7ea28df